### PR TITLE
Set ITSAppUsesNonExemptEncryption key to false

### DIFF
--- a/App/SupportingFiles/Info.plist
+++ b/App/SupportingFiles/Info.plist
@@ -41,5 +41,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 </dict>
 </plist>


### PR DESCRIPTION
# Set ITSAppUsesNonExemptEncryption key to false

On request of @kaydollt.

This change will enables us to automatically release a new build to testflight, without the need of denying nonexempt encryption manually in AppStore Connect.

However Apps that use nonexempt encryption have to change the value of the key to YES as of implementation.

