### PR TITLE
Implement Navigation Controller Suffix rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -185,9 +185,9 @@ custom_rules:
     severity: warning
   controller_class_name_suffix:
     included: ".*.swift"
-    regex: 'class +\w+(?<!View|Flow)Controller'
+    regex: 'class +\w+(?<!View|Navigation|Flow)Controller'
     name: "Controller Class Name Suffix"
-    message: "Only use the `Controller` class name suffix for ViewControllers or FlowControllers."
+    message: "Only use the `Controller` class name suffix for ViewControllers, NavigationControllers, or FlowControllers."
     severity: warning
   debug_log_level:
     included: ".*.swift"

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -141,6 +141,12 @@ custom_rules:
     name: "Class Name Suffix View Controller"
     message: "All `ViewController` subclasses should end on `ViewController`."
     severity: warning
+  class_name_suffix_navigation_controller:
+    included: ".*.swift"
+    regex: 'class +\w+(?<!NavigationController) *(?:<[^>]+>)? *: +\w+NavigationController'
+    name: "Class Name Suffix View Controller"
+    message: "All `NavigationController` subclasses should end on `NavigationController`."
+    severity: warning
   closing_brace_whitespace:
     included: ".*.swift"
     regex: '(?:\n| {2,})\}\)? *\n *[^ \n\})\]s#"]'


### PR DESCRIPTION
Resolves a swiftlint rule issue which produced a warning when NavigationController was used as a suffix for a subclass of UINavigationController.