### PR TITLE
Remove swfitlint rule no_extension_access_modifier

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -31,7 +31,6 @@ opt_in_rules:
 - multiline_parameters
 - multiline_parameters_brackets
 - nimble_operator
-- no_extension_access_modifier
 - number_separator
 - object_literal
 - operator_usage_whitespace


### PR DESCRIPTION
Allows access levels for extensions. Should be merged with together with https://github.com/JamitLabs/ProjLintTemplates/pull/5