### PR TITLE
Adds a hooks script which currently configures pre-commit hooks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,7 @@ Scripts/SymLinks
 # Accio dependency management
 Dependencies/
 .accio/
+
+
+# Beak Scripts' user-specific symbolic links
+Scripts/SymLinks/

--- a/README.md.sample
+++ b/README.md.sample
@@ -18,5 +18,6 @@ Once the project is set up as above, the following script commands should be ava
 * `deps update`: Updates all dependencies according to their version specifications.
 * `tools install`: Installes missing tools & updates all existing to their latest versions.
 * `ci lint`: Lints the project with all configured linters like it would on the CI.
+* `hooks register`: Registers git hooks for the project to ensure you get notified of potential issues e.g. before committing.
 
 Feel free to add more scripts in the `Scripts` folder. To edit them, run `beak edit -p Scripts/<file>.swift` which will start [Beak's edit mode](https://github.com/yonaskolb/Beak#edit-the-swift-file). Once you are done and saved your changes, make sure to run `beak run link` to ensure all scripts are still executables. (The edit mode of Beak will destroy the rights on save.)

--- a/Scripts/ci.swift
+++ b/Scripts/ci.swift
@@ -30,7 +30,6 @@ public func lint() throws {
 
 // MARK: - Helpers
 private func lint(bash command: String) -> RunOutput {
-
     return run(bash: command)
 }
 

--- a/Scripts/hooks.swift
+++ b/Scripts/hooks.swift
@@ -16,8 +16,11 @@ public func register() throws {
 
     let preCommitContents: String = """
       #!/bin/bash
+      echo 'Linting project with BartyCrouch ...'
       bartycrouch lint --fail-on-warnings
-      swiftlint lint --strict --quiet
+
+      echo 'Linting project with SwiftLint ...'
+      swiftlint lint --strict
       """
 
     try execute(bash: "echo '\(preCommitContents)' > .git/hooks/pre-commit")

--- a/Scripts/hooks.swift
+++ b/Scripts/hooks.swift
@@ -1,0 +1,35 @@
+#!/usr/bin/env beak run --path
+
+// MARK: - Script Dependencies
+// beak: kareman/SwiftShell @ .upToNextMajor(from: "4.1.2")
+// beak: onevcat/Rainbow @ .upToNextMajor(from: "3.1.2")
+
+import Foundation
+import Rainbow
+import SwiftShell
+import PackageConfig
+
+// MARK: - Runnable Tasks
+/// Updates all dependencies specified in the project according to their version requirements.
+public func register() throws {
+    try execute(bash: "mkdir -p .git/hooks")
+
+    let preCommitContents: String = """
+      #!/bin/bash
+      bartycrouch lint --fail-on-warnings
+      swiftlint lint --strict --quiet
+      """
+
+    try execute(bash: "echo '\(preCommitContents)' > .git/hooks/pre-commit")
+}
+
+/// Installs all dependencies with the exact versions specified on last update.
+public func unregister() throws {
+    try execute(bash: "rm -rf .git/hooks")
+}
+
+// MARK: - Helpers
+private func execute(bash command: String) throws {
+    print("⏳ Executing '\(command.italic.lightYellow)'".bold)
+    try runAndPrint(bash: command)
+}

--- a/Scripts/hooks.swift
+++ b/Scripts/hooks.swift
@@ -7,7 +7,6 @@
 import Foundation
 import Rainbow
 import SwiftShell
-import PackageConfig
 
 // MARK: - Runnable Tasks
 /// Registers git hooks for the project to ensure you get notified of potential issues e.g. before committing.

--- a/Scripts/hooks.swift
+++ b/Scripts/hooks.swift
@@ -10,7 +10,7 @@ import SwiftShell
 import PackageConfig
 
 // MARK: - Runnable Tasks
-/// Updates all dependencies specified in the project according to their version requirements.
+/// Registers git hooks for the project to ensure you get notified of potential issues e.g. before committing.
 public func register() throws {
     try execute(bash: "mkdir -p .git/hooks")
 
@@ -23,7 +23,7 @@ public func register() throws {
     try execute(bash: "echo '\(preCommitContents)' > .git/hooks/pre-commit")
 }
 
-/// Installs all dependencies with the exact versions specified on last update.
+/// Unregisters any registered git hooks.
 public func unregister() throws {
     try execute(bash: "rm -rf .git/hooks")
 }

--- a/Scripts/hooks.swift
+++ b/Scripts/hooks.swift
@@ -21,6 +21,7 @@ public func register() throws {
       """
 
     try execute(bash: "echo '\(preCommitContents)' > .git/hooks/pre-commit")
+    try execute(bash: "chmod +x .git/hooks/pre-commit")
 }
 
 /// Unregisters any registered git hooks.


### PR DESCRIPTION
The hooks can be registered by running `hooks register` (don't forget to run `beak run link` if you don't have already) or uninstalled by `hooks unregister` if you don't want them any more. Note that installing the hooks is recommended to _all_ developers.