### PR TITLE
Use nested_type_separator option for file_name rule

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -85,6 +85,7 @@ file_header:
   required_pattern: \/\/ Copyright © \d{4} Jamit Labs GmbH\. All rights reserved\.
 
 file_name:
+  nested_type_separator: ""
   suffix_pattern: "Extensions?|\\+.*"
 
 file_types_order:


### PR DESCRIPTION
Previously, if there was a file extending a nested type, it had a `.` in its file name: e. g. `UIView.AnimationOptionsExtension.swift`.

With this rule, names without additional `.` characters, e. g. `UIViewAnimationOptionsExtension.swift`, will be required.

Should be merged together with https://github.com/JamitLabs/ProjLintTemplates/pull/7.